### PR TITLE
🔧 Fix GitOps Workflow: Reactivate GitHub Actions

### DIFF
--- a/.github/workflows/gitops-deployment.yml
+++ b/.github/workflows/gitops-deployment.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: [main, develop]
     paths: ["live_terraform_project/**"]
+  workflow_dispatch:
   schedule:
     # Drift detection every 6 hours
     - cron: "0 */6 * * *"
@@ -78,7 +79,6 @@ jobs:
       - name: 🔒 Security Scan
         run: |
           cd live_terraform_project
-          # Install and run security tools
           pip install checkov
           checkov -d . --framework terraform || true
 
@@ -100,7 +100,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const output = `
+            const output = \`
             #### 🏗️ Terraform Plan Results - ${{ needs.detect-environment.outputs.environment }}
 
             **Status**: ${{ steps.plan.outcome == 'success' && '✅ Success' || '❌ Failed' }}
@@ -109,9 +109,9 @@ jobs:
 
             <details><summary>📊 Show Plan Details</summary>
 
-            \`\`\`
+            \\\`\\\`\\\`
             ${{ steps.plan.outputs.stdout }}
-            \`\`\`
+            \\\`\\\`\\\`
 
             </details>
 
@@ -120,7 +120,7 @@ jobs:
             - 🔍 Security scan completed
             - 💰 Cost estimation included
             - 📋 Ready for deployment
-            `;
+            \`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -194,7 +194,6 @@ jobs:
 
           if [ $? -eq 2 ]; then
             echo "🚨 DRIFT DETECTED in ${{ matrix.environment }}"
-            # Could create GitHub issue or send alert here
           else
             echo "✅ No drift detected in ${{ matrix.environment }}"
           fi


### PR DESCRIPTION
## Problem
The GitOps workflow was marked as 'deleted' by GitHub, preventing it from triggering on PRs.

## Solution
- Added `workflow_dispatch` trigger to reactivate the workflow
- This allows manual triggering and should reactivate automatic triggers
- Fixed the workflow syntax to ensure proper GitHub Actions recognition

## Expected Result
- Workflows should now appear in the Actions tab
- PRs with `live_terraform_project/**` changes should trigger the GitOps workflow
- Manual workflow runs should be possible

## Testing
After merging, test by:
1. Checking that workflows appear in the Actions tab
2. Creating a new PR with Terraform changes
3. Manually triggering the workflow if needed