### PR TITLE
🔧 Fix GitOps Workflow for PR Events

### DIFF
--- a/.github/workflows/gitops-deployment.yml
+++ b/.github/workflows/gitops-deployment.yml
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: 🏗️ Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -144,6 +146,8 @@ jobs:
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: 🏗️ Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -179,6 +183,8 @@ jobs:
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: 🏗️ Setup Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
## 🎯 Critical Fix for GitOps PR Workflows

### 🐛 Problem Solved
The GitOps workflow was failing on PR events because it was checking out the target branch instead of the PR branch content. This caused `live_terraform_project` directory to be empty during PR workflows.

### ✅ Solution Implemented
Updated all `actions/checkout@v4` steps to use:
```yaml
with:
  ref: ${{ github.event.pull_request.head.sha || github.ref }}
```

This ensures:
- **PR events**: Checkout the PR branch content (with new Terraform files)
- **Push events**: Checkout the normal branch (existing behavior)
- **Manual dispatch**: Use the target branch

### 🧪 Testing Impact
- Fixes DevOps AI Agent PR workflow triggers
- Enables proper GitOps validation of Terraform changes in PRs
- Ensures `live_terraform_project/**` files are available during workflow execution

**Ready for immediate merge** - This unblocks the Development-First GitOps strategy! 🚀