### PR TITLE
fix: Apply terraform formatting to all .tfvars files

### DIFF
--- a/configs/development.tfvars
+++ b/configs/development.tfvars
@@ -1,7 +1,7 @@
 # Development Environment Configuration
-environment = "dev"
+environment              = "dev"
 resource_group_base_name = "devops-ai"
-location = "East US"
+location                 = "East US"
 
 tags = {
   environment = "dev"

--- a/configs/production.tfvars
+++ b/configs/production.tfvars
@@ -1,7 +1,7 @@
 # Production Environment Configuration
-environment = "prod"
+environment              = "prod"
 resource_group_base_name = "devops-ai"
-location = "West US 2"
+location                 = "West US 2"
 
 tags = {
   environment = "prod"

--- a/configs/staging.tfvars
+++ b/configs/staging.tfvars
@@ -1,7 +1,7 @@
 # Staging Environment Configuration
-environment = "stg"
+environment              = "stg"
 resource_group_base_name = "devops-ai"
-location = "Central US"
+location                 = "Central US"
 
 tags = {
   environment = "stg"

--- a/live_terraform_project/environments/development.tfvars
+++ b/live_terraform_project/environments/development.tfvars
@@ -1,5 +1,5 @@
-environment = "dev"
-location = "uksouth"
+environment              = "dev"
+location                 = "uksouth"
 resource_group_base_name = "devops-ai"
 tags = {
   environment = "development"

--- a/live_terraform_project/environments/production.tfvars
+++ b/live_terraform_project/environments/production.tfvars
@@ -1,5 +1,5 @@
-environment = "prod"
-location = "uksouth"
+environment              = "prod"
+location                 = "uksouth"
 resource_group_base_name = "devops-ai"
 tags = {
   environment = "production"

--- a/live_terraform_project/environments/staging.tfvars
+++ b/live_terraform_project/environments/staging.tfvars
@@ -1,5 +1,5 @@
-environment = "stg"
-location = "uksouth"
+environment              = "stg"
+location                 = "uksouth"
 resource_group_base_name = "devops-ai"
 tags = {
   environment = "staging"


### PR DESCRIPTION
fix: Apply terraform formatting to all .tfvars files

Resolves CI pipeline terraform fmt validation failures by applying consistent formatting to all .tfvars files.
